### PR TITLE
Add deploy workflow to push COPASI Docker image on release tags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,17 +1,25 @@
 name: Publish Docker
+
 on:
   release:
     types: [published]
+
 jobs:
   build:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@master
-      - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
-        with:
-          name: crbm/biosimulations_copasi_api
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          auto_tag: true
-          snapshot: true
+      - uses: actions/checkout@v1
+      - name: Login to DockerHub Registry
+        run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+      - name: Get the version
+        id: vars
+        run: echo ::set-output name=tag::$(echo ${GITHUB_REF:10})
+      - name: Build the tagged Docker image
+        run: docker build . --file Dockerfile --tag crbmapi/biosimulations_copasi_api:${{steps.vars.outputs.tag}}
+      - name: Push the tagged Docker image
+        run: docker push crbmapi/biosimulations_copasi_api:${{steps.vars.outputs.tag}}
+      - name: Build the latest Docker image
+        run: docker build . --file Dockerfile --tag crbmapi/biosimulations_copasi_api:latest
+      - name: Push the latest Docker image
+        run: docker push crbmapi/biosimulations_copasi_api:latest


### PR DESCRIPTION
Auto build and push docker image to dockerhub of master branch and release tag every time for building latest singularity image on HPC