### PR TITLE
Updating version of utils backend.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-biosimulators_utils[logging,sbml] >= 0.1.128
+biosimulators_utils[logging,smbl] >= 0.1.175
 kisao
 lxml
 numpy


### PR DESCRIPTION
_**Problem scenario**_
As there have been substantial updates to the utils module since the last configuration of bounds for `biosimulators-copasi`, running `pip install biosimulators-copasi` could potentially install an old version of `biosimulators-utils`. This could potentially effect something like: #56.

------

_**Addresses a need for the following:**_

An updated share dependency commonality. 

------

_**What does this PR do?**_

Adjusts the required bounds for `biosimulator-utils` to be `>= 0.1.175`.

------

_**To Do PRIOR to merge**_

None.

