### PR TITLE
Refactor relative imports

### DIFF
--- a/biosimulators_copasi/core.py
+++ b/biosimulators_copasi/core.py
@@ -21,8 +21,8 @@ from biosimulators_utils.simulator.utils import get_algorithm_substitution_polic
 from biosimulators_utils.utils.core import raise_errors_warnings
 from biosimulators_utils.warnings import warn, BioSimulatorsWarning
 from kisao.data_model import AlgorithmSubstitutionPolicy, ALGORITHM_SUBSTITUTION_POLICY_LEVELS
-from .data_model import KISAO_ALGORITHMS_MAP, Units
-from .utils import (get_algorithm_id, set_algorithm_parameter_value,
+from biosimulators_copasi.data_model import KISAO_ALGORITHMS_MAP, Units
+from biosimulators_copasi.utils import (get_algorithm_id, set_algorithm_parameter_value,
                     get_copasi_model_object_by_sbml_id, get_copasi_model_obj_sbml_ids,
                     fix_copasi_generated_combine_archive as fix_copasi_generated_combine_archive_func)
 import COPASI
@@ -76,10 +76,10 @@ def exec_sedml_docs_in_combine_archive(archive_filename: str, out_dir: str, conf
     return result
 
 
-def exec_sed_doc(doc: Union[SedDocument, str], working_dir: str, base_out_path: str, 
-                 rel_out_path: Optional[str] = None, apply_xml_model_changes: bool = True, 
-                 log: Optional[SedDocumentLog] = None, indent: int = 0, pretty_print_modified_xml_models: bool = False, 
-                 log_level: Optional[StandardOutputErrorCapturerLevel] = None,
+def exec_sed_doc(doc: Union[SedDocument, str], working_dir: str, base_out_path: str, rel_out_path: Optional[str] = None, 
+                 apply_xml_model_changes: bool = True, log: Optional[SedDocumentLog] = None, 
+                 indent: int = 0, pretty_print_modified_xml_models: bool = False, 
+                 log_level: Optional[Union[StandardOutputErrorCapturerLevel, str]] = StandardOutputErrorCapturerLevel.c,
                  config: Optional[Config] = None) -> Tuple[ReportResults, SedDocumentLog]:
     """ Execute the tasks specified in a SED document and generate the specified outputs
 
@@ -110,7 +110,6 @@ def exec_sed_doc(doc: Union[SedDocument, str], working_dir: str, base_out_path: 
             * :obj:`ReportResults`: results of each report
             * :obj:`SedDocumentLog`: log of the document
     """
-    log_level = log_level or StandardOutputErrorCapturerLevel.c
     return base_exec_sed_doc(exec_sed_task, doc, working_dir, base_out_path,
                              rel_out_path=rel_out_path,
                              apply_xml_model_changes=apply_xml_model_changes,
@@ -148,7 +147,8 @@ def exec_sed_task(task: Task, variables: List[Variable], preprocessed_task: Opti
     
     config = config or get_config() # noqa python:S3776
     
-    log = TaskLog() if not log and config.LOG else log # noqa python:S3776
+    if not log and config.LOG: # noqa python:S3776
+        log = TaskLog() # noqa python:S3776
     
     if not preprocessed_task: # noqa python:S3776
         preprocessed_task = preprocess_sed_task(task, variables, config=config) # noqa python:S3776

--- a/biosimulators_copasi/core.py
+++ b/biosimulators_copasi/core.py
@@ -76,9 +76,10 @@ def exec_sedml_docs_in_combine_archive(archive_filename: str, out_dir: str, conf
     return result
 
 
-def exec_sed_doc(doc: Union[SedDocument, str], working_dir: str, base_out_path: str, rel_out_path: Optional[str] = None,
-                 apply_xml_model_changes: bool = True, log: Optional[SedDocumentLog] = None, indent: int = 0,
-                 pretty_print_modified_xml_models: bool = False, log_level=StandardOutputErrorCapturerLevel.c,
+def exec_sed_doc(doc: Union[SedDocument, str], working_dir: str, base_out_path: str, 
+                 rel_out_path: Optional[str] = None, apply_xml_model_changes: bool = True, 
+                 log: Optional[SedDocumentLog] = None, indent: int = 0, pretty_print_modified_xml_models: bool = False, 
+                 log_level: Optional[StandardOutputErrorCapturerLevel] = None,
                  config: Optional[Config] = None) -> Tuple[ReportResults, SedDocumentLog]:
     """ Execute the tasks specified in a SED document and generate the specified outputs
 
@@ -109,6 +110,7 @@ def exec_sed_doc(doc: Union[SedDocument, str], working_dir: str, base_out_path: 
             * :obj:`ReportResults`: results of each report
             * :obj:`SedDocumentLog`: log of the document
     """
+    log_level = log_level or StandardOutputErrorCapturerLevel.c
     return base_exec_sed_doc(exec_sed_task, doc, working_dir, base_out_path,
                              rel_out_path=rel_out_path,
                              apply_xml_model_changes=apply_xml_model_changes,

--- a/biosimulators_copasi/utils.py
+++ b/biosimulators_copasi/utils.py
@@ -8,7 +8,7 @@
 
 from types import FunctionType #PR: 55 
 from typing import Dict, List, Tuple, Union, Optional #PR: 55
-from .data_model import KISAO_ALGORITHMS_MAP, KISAO_PARAMETERS_MAP, Units
+from biosimulators_copasi.data_model import KISAO_ALGORITHMS_MAP, KISAO_PARAMETERS_MAP, Units
 from biosimulators_utils.combine.data_model import CombineArchiveContentFormat
 from biosimulators_utils.combine.io import CombineArchiveReader, CombineArchiveWriter
 from biosimulators_utils.config import get_config, Config  # noqa: F401


### PR DESCRIPTION
_**Addresses a need for the following:**_
changing instances of imports which are relative in nature to become absolute.

------
_**Justification:**_
I propose that absolute imports would provide the following aspects to our codebase:

_Clarity_: Absolute imports provide a clear indication of where the imported modules come from. When you use an absolute import, you explicitly specify the complete path to the module or package that you want to import, which makes it easier for other developers (and your future self) to understand the structure of your project.

_Avoiding naming conflicts_: When you use a relative import, you risk running into naming conflicts if multiple modules with the same name exist in different packages. With an absolute import, you can ensure that you're importing the correct module every time. This is particularly pertinent in this repository's case.

_Future-proofing_: Absolute imports are more future-proof than relative imports because they're less likely to break if you refactor your code or move modules around in your project. If you use relative imports and then move a module to a different location in your project, you'll need to update all the relative import statements that reference that module.

_Consistency_: Using absolute imports throughout your project ensures consistency in your codebase, which can make it easier to read and maintain.