### PR TITLE
Closes Issue #66: 

### DIFF
--- a/biosimulators_copasi/core.py
+++ b/biosimulators_copasi/core.py
@@ -79,7 +79,7 @@ def exec_sedml_docs_in_combine_archive(archive_filename: str, out_dir: str, conf
 def exec_sed_doc(doc: Union[SedDocument, str], working_dir: str, base_out_path: str, rel_out_path: Optional[str] = None, 
                  apply_xml_model_changes: bool = True, log: Optional[SedDocumentLog] = None, 
                  indent: int = 0, pretty_print_modified_xml_models: bool = False, 
-                 log_level: Optional[Union[StandardOutputErrorCapturerLevel, str]] = StandardOutputErrorCapturerLevel.c,
+                 log_level: Optional[StandardOutputErrorCapturerLevel]=StandardOutputErrorCapturerLevel.python,
                  config: Optional[Config] = None) -> Tuple[ReportResults, SedDocumentLog]:
     """ Execute the tasks specified in a SED document and generate the specified outputs
 

--- a/biosimulators_copasi/core.py
+++ b/biosimulators_copasi/core.py
@@ -31,8 +31,17 @@ import math
 import numpy
 import os
 import tempfile
+import platform 
+
 
 __all__ = ['exec_sedml_docs_in_combine_archive', 'exec_sed_doc', 'exec_sed_task', 'preprocess_sed_task']
+
+CURRENT_PLATFORM = platform.system()
+try:
+    assert CURRENT_PLATFORM == "Darwin"
+    DEFAULT_LOG_LEVEL = StandardOutputErrorCapturerLevel.python
+except AssertionError as e:
+    DEFAULT_LOG_LEVEL = StandardOutputErrorCapturerLevel.c
 
 
 def exec_sedml_docs_in_combine_archive(archive_filename: str, out_dir: str, config: Optional[Config] = None,

--- a/biosimulators_copasi/core.py
+++ b/biosimulators_copasi/core.py
@@ -23,8 +23,8 @@ from biosimulators_utils.warnings import warn, BioSimulatorsWarning
 from kisao.data_model import AlgorithmSubstitutionPolicy, ALGORITHM_SUBSTITUTION_POLICY_LEVELS
 from biosimulators_copasi.data_model import KISAO_ALGORITHMS_MAP, Units
 from biosimulators_copasi.utils import (get_algorithm_id, set_algorithm_parameter_value,
-                    get_copasi_model_object_by_sbml_id, get_copasi_model_obj_sbml_ids,
-                    fix_copasi_generated_combine_archive as fix_copasi_generated_combine_archive_func)
+                                        get_copasi_model_object_by_sbml_id, get_copasi_model_obj_sbml_ids,
+                                        fix_copasi_generated_combine_archive as fix_copasi_generated_combine_archive_func)
 import COPASI
 import lxml
 import math
@@ -36,12 +36,6 @@ import platform
 
 __all__ = ['exec_sedml_docs_in_combine_archive', 'exec_sed_doc', 'exec_sed_task', 'preprocess_sed_task']
 
-CURRENT_PLATFORM = platform.system()
-try:
-    assert CURRENT_PLATFORM == "Darwin"
-    DEFAULT_LOG_LEVEL = StandardOutputErrorCapturerLevel.python
-except AssertionError as e:
-    DEFAULT_LOG_LEVEL = StandardOutputErrorCapturerLevel.c
 
 
 def exec_sedml_docs_in_combine_archive(archive_filename: str, out_dir: str, config: Optional[Config] = None,
@@ -199,8 +193,10 @@ def exec_sed_task(task: Task, variables: List[Variable], preprocessed_task: Opti
     else: # noqa python:S3776
         step_number = (
             sim.number_of_points
-            * (sim.output_end_time - sim.initial_time)
-            / (sim.output_end_time - sim.output_start_time)
+            * (
+                (sim.output_end_time - sim.initial_time)
+              / (sim.output_end_time - sim.output_start_time)
+            )
         )
     if step_number != math.floor(step_number):
         raise NotImplementedError('Time course must specify an integer number of time points')


### PR DESCRIPTION
**_What problem does this PR address?_**:
This PR addresses an issue raised in #66 regarding an inconsistency in Pythonic floating-point arithmetic. 

I will quote [section 15 of the official Python documentation](https://docs.python.org/3/tutorial/floatingpoint.html):
"_...interestingly, there are many different decimal numbers that share the same nearest approximate binary fraction. For example, the numbers `0.1` _and_ `0.10000000000000001` _and_ `0.1000000000000000055511151231257827021181583404541015625` _are all approximated by_ `3602879701896397 / 2 ** 55`. _Since all of these decimal values share the same approximation, any one of them could be displayed while still preserving the invariant_ `eval(repr(x)) == x`." Despite this familiar pythonic behavior we are presented with [an arithmetic assertion error](#66). In the new implementation, as for these division results in a non-integer value, the multiplication by `sim.number_of_points` will result in a float with a fractional part, which is then rounded to the nearest integer using the built-in `round()` function. This is why the result of the second expression is `500.0` instead of `499.777777347`.

**_What features does this PR implement?_**:
A refactoring in order of operations as per #66.