### PR TITLE
adjusted import order to be PEP-compliant

### DIFF
--- a/biosimulators_copasi/__main__.py
+++ b/biosimulators_copasi/__main__.py
@@ -18,7 +18,6 @@ from biosimulators_utils.simulator.cli import build_cli
 from biosimulators_utils.simulator.data_model import EnvironmentVariable
 from biosimulators_utils.simulator.environ import ENVIRONMENT_VARIABLES as DEFAULT_ENVIRONMENT_VARIABLES
 
-
 ENVIRONMENT_VARIABLES = list(DEFAULT_ENVIRONMENT_VARIABLES.values())
 ENVIRONMENT_VARIABLES.append(
     EnvironmentVariable(

--- a/biosimulators_copasi/__main__.py
+++ b/biosimulators_copasi/__main__.py
@@ -7,6 +7,8 @@
 :License: MIT
 """
 
+import cement
+import termcolor
 from . import get_simulator_version
 from ._version import __version__
 from .core import exec_sedml_docs_in_combine_archive
@@ -15,8 +17,7 @@ from biosimulators_utils.config import get_config
 from biosimulators_utils.simulator.cli import build_cli
 from biosimulators_utils.simulator.data_model import EnvironmentVariable
 from biosimulators_utils.simulator.environ import ENVIRONMENT_VARIABLES as DEFAULT_ENVIRONMENT_VARIABLES
-import cement
-import termcolor
+
 
 ENVIRONMENT_VARIABLES = list(DEFAULT_ENVIRONMENT_VARIABLES.values())
 ENVIRONMENT_VARIABLES.append(

--- a/biosimulators_copasi/core.py
+++ b/biosimulators_copasi/core.py
@@ -7,7 +7,15 @@
 :License: MIT
 """
 
+
+import lxml
+import math
+import numpy
+import os
+import tempfile
+import platform 
 from typing import Dict, List, Tuple, Union, Optional  
+import COPASI
 from biosimulators_utils.combine.exec import exec_sedml_docs_in_archive
 from biosimulators_utils.config import get_config, Config  # noqa: F401
 from biosimulators_utils.log.data_model import CombineArchiveLog, TaskLog, StandardOutputErrorCapturerLevel, SedDocumentLog  # noqa: F401  
@@ -25,13 +33,6 @@ from biosimulators_copasi.data_model import KISAO_ALGORITHMS_MAP, Units
 from biosimulators_copasi.utils import (get_algorithm_id, set_algorithm_parameter_value,
                     get_copasi_model_object_by_sbml_id, get_copasi_model_obj_sbml_ids,
                     fix_copasi_generated_combine_archive as fix_copasi_generated_combine_archive_func)
-import COPASI
-import lxml
-import math
-import numpy
-import os
-import tempfile
-import platform 
 
 
 __all__ = ['exec_sedml_docs_in_combine_archive', 'exec_sed_doc', 'exec_sed_task', 'preprocess_sed_task']

--- a/biosimulators_copasi/core.py
+++ b/biosimulators_copasi/core.py
@@ -16,6 +16,7 @@ import tempfile
 import platform 
 from typing import Dict, List, Tuple, Union, Optional  
 import COPASI
+from kisao.data_model import AlgorithmSubstitutionPolicy, ALGORITHM_SUBSTITUTION_POLICY_LEVELS
 from biosimulators_utils.combine.exec import exec_sedml_docs_in_archive
 from biosimulators_utils.config import get_config, Config  # noqa: F401
 from biosimulators_utils.log.data_model import CombineArchiveLog, TaskLog, StandardOutputErrorCapturerLevel, SedDocumentLog  # noqa: F401  
@@ -28,7 +29,6 @@ from biosimulators_utils.sedml.exec import exec_sed_doc as base_exec_sed_doc
 from biosimulators_utils.simulator.utils import get_algorithm_substitution_policy
 from biosimulators_utils.utils.core import raise_errors_warnings
 from biosimulators_utils.warnings import warn, BioSimulatorsWarning
-from kisao.data_model import AlgorithmSubstitutionPolicy, ALGORITHM_SUBSTITUTION_POLICY_LEVELS
 from biosimulators_copasi.data_model import KISAO_ALGORITHMS_MAP, Units
 from biosimulators_copasi.utils import (get_algorithm_id, set_algorithm_parameter_value,
                     get_copasi_model_object_by_sbml_id, get_copasi_model_obj_sbml_ids,

--- a/biosimulators_copasi/data_model.py
+++ b/biosimulators_copasi/data_model.py
@@ -6,9 +6,10 @@
 :License: MIT
 """
 
-from biosimulators_utils.data_model import ValueType
 import collections
 import enum
+from biosimulators_utils.data_model import ValueType
+
 
 __all__ = ['Units', 'KISAO_ALGORITHMS_MAP', 'KISAO_PARAMETERS_MAP']
 

--- a/biosimulators_copasi/data_model.py
+++ b/biosimulators_copasi/data_model.py
@@ -10,7 +10,6 @@ import collections
 import enum
 from biosimulators_utils.data_model import ValueType
 
-
 __all__ = ['Units', 'KISAO_ALGORITHMS_MAP', 'KISAO_PARAMETERS_MAP']
 
 


### PR DESCRIPTION
**Justification**:

According to [PEP8](https://peps.python.org/pep-0008/#imports):
`Imports should be grouped in the following order:`

`Standard library imports.`
`Related third party imports.`
`Local application/library specific imports.`

This PR serves to fit that protocol.